### PR TITLE
Fix .cabal file for newer cabals

### DIFF
--- a/interpolatedstring-perl6.cabal
+++ b/interpolatedstring-perl6.cabal
@@ -1,5 +1,5 @@
 Name:          interpolatedstring-perl6
-Version:       1.0.0
+Version:       1.0.1
 License:       PublicDomain
 License-file:  LICENSE
 Category:      Data
@@ -7,7 +7,7 @@ Author:        Audrey Tang
 Copyright:     Audrey Tang
 Maintainer:    Audrey Tang <audreyt@audreyt.org>
 Stability:     stable
-Cabal-Version: >= 1.6
+Cabal-Version: >= 1.10
 Build-Type:    Custom
 Synopsis:      QuasiQuoter for Perl6-style multi-line interpolated strings
 Description:   QuasiQuoter for Perl6-style multi-line interpolated strings with \"q\", \"qq\" and \"qc\" support.
@@ -18,7 +18,14 @@ Source-Repository head
     location: git://github.com/audreyt/interpolatedstring-perl6.git
 
 library
-    extensions:      TemplateHaskell, TypeSynonymInstances, FlexibleInstances, UndecidableInstances, OverlappingInstances
+    default-extensions: TemplateHaskell, TypeSynonymInstances, FlexibleInstances, UndecidableInstances, OverlappingInstances
+    default-language: Haskell2010
     build-depends:   base > 4 && < 5, template-haskell >= 2.5, haskell-src-meta >= 0.3, text, bytestring
     hs-source-dirs:  src
     exposed-modules: Text.InterpolatedString.Perl6
+
+custom-setup
+    setup-depends:
+        base >= 4 && < 5,
+        Cabal >= 1.10,
+        process


### PR DESCRIPTION
An implicit constraint of <1.25 was in effect, due to
https://github.com/haskell/cabal/issues/5278